### PR TITLE
per-thread request cache

### DIFF
--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -94,7 +94,7 @@ static inline int MPIR_Handle_free(void *((*indirect)[]), int indirect_size)
 #endif
 
 static inline void *MPIR_Handle_direct_init(void *direct,
-                                            int direct_size, int obj_size, int handle_type, int bucket)
+                                            int direct_size, int obj_size, int handle_type)
 {
     int i;
     MPIR_Handle_common *hptr = 0;
@@ -108,7 +108,7 @@ static inline void *MPIR_Handle_direct_init(void *direct,
         ptr = ptr + obj_size;
         hptr->next = ptr;
         hptr->handle = ((unsigned) HANDLE_KIND_DIRECT << HANDLE_KIND_SHIFT) |
-            (handle_type << HANDLE_MPI_KIND_SHIFT) | (bucket << HANDLE_BUCKET_SHIFT) | i;
+            (handle_type << HANDLE_MPI_KIND_SHIFT) | i;
 
         HANDLE_VG_LABEL(hptr, obj_size, handle_type, 1);
     }
@@ -123,7 +123,7 @@ static inline void *MPIR_Handle_indirect_init(void *(**indirect)[],
                                               int *indirect_size,
                                               int indirect_num_blocks,
                                               int indirect_num_indices,
-                                              int obj_size, int handle_type, int bucket)
+                                              int obj_size, int handle_type)
 {
     void *block_ptr;
     MPIR_Handle_common *hptr = 0;
@@ -160,8 +160,8 @@ static inline void *MPIR_Handle_indirect_init(void *(**indirect)[],
         ptr = ptr + obj_size;
         hptr->next = ptr;
         hptr->handle = ((unsigned) HANDLE_KIND_INDIRECT << HANDLE_KIND_SHIFT) |
-            (handle_type << HANDLE_MPI_KIND_SHIFT) | (bucket << HANDLE_BUCKET_SHIFT) | (*indirect_size << HANDLE_INDIRECT_SHIFT) | i;
-        //printf("handle=%#x handle_type=%x bucket=%d *indirect_size=%d i=%d\n", hptr->handle, handle_type, bucket, *indirect_size, i);
+            (handle_type << HANDLE_MPI_KIND_SHIFT) | (*indirect_size << HANDLE_INDIRECT_SHIFT) | i;
+        /* printf("handle=%#x handle_type=%x *indirect_size=%d i=%d\n", hptr->handle, handle_type, *indirect_size, i); */
 
         HANDLE_VG_LABEL(hptr, obj_size, handle_type, 0);
     }
@@ -213,7 +213,6 @@ Input Parameters:
   locking with a single global mutex and with a mutex specific for handles.
 
   +*/
-
 #undef FUNCNAME
 #define FUNCNAME MPIR_Handle_obj_alloc
 #undef FCNAME
@@ -246,11 +245,10 @@ static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t * objmem)
         /* ptr points to object to allocate */
     }
     else {
-        int objsize, objkind, bucket;
+        int objsize, objkind;
 
         objsize = objmem->size;
         objkind = objmem->kind;
-        bucket = objmem->bucket;
 
         if (!objmem->initialized) {
             MPL_VG_CREATE_MEMPOOL(objmem, 0 /*rzB */ , 0 /*is_zeroed */);
@@ -259,7 +257,7 @@ static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t * objmem)
              * jobs do not need to include any of the Info code if no
              * Info-using routines are used */
             objmem->initialized = 1;
-            ptr = MPIR_Handle_direct_init(objmem->direct, objmem->direct_size, objsize, objkind, bucket);
+            ptr = MPIR_Handle_direct_init(objmem->direct, objmem->direct_size, objsize, objkind);
             if (ptr) {
                 objmem->avail = ptr->next;
             }
@@ -280,7 +278,7 @@ static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t * objmem)
             ptr = MPIR_Handle_indirect_init(&objmem->indirect,
                                             &objmem->indirect_size,
                                             HANDLE_NUM_BLOCKS,
-                                            HANDLE_NUM_INDICES, objsize, objkind, bucket);
+                                            HANDLE_NUM_INDICES, objsize, objkind);
             if (ptr) {
                 objmem->avail = ptr->next;
             }

--- a/src/include/mpir_thread.h
+++ b/src/include/mpir_thread.h
@@ -51,6 +51,7 @@ extern OPA_int_t num_server_thread;
 /* arbitrary, just needed to avoid cleaning up heap allocated memory at thread
  * destruction time */
 #define MPIR_STRERROR_BUF_SIZE (1024)
+#define MPIR_THREAD_REQUEST_CACHE (64)
 
 /* This structure contains all thread-local variables and will be zeroed at
  * allocation time.
@@ -71,6 +72,9 @@ typedef struct {
 #ifdef MPICH_THREAD_USE_MDTA
     MPIR_Thread_sync_t sync;
 #endif
+
+    MPIR_Request *request_cache[MPIR_THREAD_REQUEST_CACHE];
+    unsigned int request_cache_cnt;
 #endif
 } MPIR_Per_thread_t;
 

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -214,10 +214,8 @@ do {                                                                \
     MPIR_Assert(err == 0);                                          \
     MPID_Thread_mutex_create(&MPIR_Grequest_class_mem.lock, &err);  \
     MPIR_Assert(err == 0);                                          \
-    for(int i = 0; i < MPIR_REQUEST_MEM_NBUCKETS; i++) {            \
-        MPID_Thread_mutex_create(&MPIR_Request_mem[i].lock, &err);  \
-        MPIR_Assert(err == 0);                                      \
-    }                                                               \
+    MPID_Thread_mutex_create(&MPIR_Request_mem.lock, &err);         \
+    MPIR_Assert(err == 0);                                          \
     MPID_Thread_mutex_create(&MPIR_Win_mem.lock, &err);             \
     MPIR_Assert(err == 0);                                          \
 } while(0)
@@ -242,10 +240,8 @@ do {                                                                \
     MPIR_Assert(err == 0);                                          \
     MPID_Thread_mutex_destroy(&MPIR_Grequest_class_mem.lock, &err); \
     MPIR_Assert(err == 0);                                          \
-    for(int i = 0; i < MPIR_REQUEST_MEM_NBUCKETS; i++) {            \
-        MPID_Thread_mutex_destroy(&MPIR_Request_mem[i].lock, &err);  \
-        MPIR_Assert(err == 0);                                      \
-    }                                                               \
+    MPID_Thread_mutex_destroy(&MPIR_Request_mem.lock, &err);        \
+    MPIR_Assert(err == 0);                                          \
     MPID_Thread_mutex_destroy(&MPIR_Win_mem.lock, &err);            \
     MPIR_Assert(err == 0);                                          \
 } while(0)
@@ -409,8 +405,6 @@ int MPIR_Init_thread(int * argc, char ***argv, int required, int * provided)
     int exit_init_cs_on_failure = 0;
     MPIR_Info *info_ptr;
 
-
-    MPIR_Request_mem_init();
     /* For any code in the device that wants to check for runtime 
        decisions on the value of isThreaded, set a provisional
        value here. We could let the MPID_Init routine override this */

--- a/src/mpi/pt2pt/mpir_request.c
+++ b/src/mpi/pt2pt/mpir_request.c
@@ -9,28 +9,10 @@
 
 /* style:PMPIuse:PMPI_Status_f2c:2 sig:0 */
 
-MPIR_Request MPIR_Request_direct[MPIR_REQUEST_MEM_NBUCKETS][MPIR_REQUEST_PREALLOC];
-MPIR_Object_alloc_t MPIR_Request_mem[MPIR_REQUEST_MEM_NBUCKETS] = {{0}};;
-
-#undef FUNCNAME
-#define FUNCNAME MPIR_Request_mem_init
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-
-void MPIR_Request_mem_init()
-{
-    for(int i = 0; i < MPIR_REQUEST_MEM_NBUCKETS; i++) {
-        MPIR_Request_mem[i].avail            = NULL;
-        MPIR_Request_mem[i].initialized      = 0;
-        MPIR_Request_mem[i].indirect         = NULL;
-        MPIR_Request_mem[i].indirect_size    = 0;
-        MPIR_Request_mem[i].kind             = MPIR_REQUEST;
-        MPIR_Request_mem[i].size             = sizeof(MPIR_Request);
-        MPIR_Request_mem[i].direct           = &MPIR_Request_direct[i][0];
-        MPIR_Request_mem[i].direct_size      = MPIR_REQUEST_PREALLOC;
-        MPIR_Request_mem[i].bucket           = i;
-    }
-}
+MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC] = {{0}};
+MPIR_Object_alloc_t MPIR_Request_mem = {
+    0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct,
+    MPIR_REQUEST_PREALLOC };
 
 #undef FUNCNAME
 #define FUNCNAME MPIR_Progress_wait_request

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -289,7 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_ssend_ack_event(struct fi_cq_tagged_entry
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_SSEND_ACK_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_SSEND_ACK_EVENT);
     mpi_errno = MPIDI_OFI_send_event(NULL, req->signal_req);
-    MPIDI_OFI_ssendack_request_t_tls_free(sreq);
+    MPIDI_OFI_ssendack_request_t_tls_free(req);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_SSEND_ACK_EVENT);
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -42,12 +42,8 @@
                        "Cannot allocate Ssendack Request");             \
     } while (0)
 
-#define MPIDI_OFI_ssendack_request_t_tls_free(sreq)             \
-do {                                                            \
-    MPIR_Request *tmp_req = (MPIR_Request *) sreq;              \
-    int bucket = HANDLE_GET_BUCKET(tmp_req->handle);            \
-    MPIR_Handle_obj_free(&MPIR_Request_mem[bucket], (sreq));    \
-} while (0)
+#define MPIDI_OFI_ssendack_request_t_tls_free(req) \
+  MPIR_Handle_obj_free(&MPIR_Request_mem, (req))
 
 #define MPIDI_OFI_ssendack_request_t_alloc_and_init(req)        \
     do {                                                                \
@@ -323,7 +319,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_datatype_unmap(MPIDI_OFI_win_datatyp
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * req)
 {
-    int count, bucket;
+    int count;
     MPIR_Assert(HANDLE_GET_MPI_KIND(req->handle) == MPIR_REQUEST);
     MPIR_Object_release_ref(req, &count);
     MPIR_Assert(count >= 0);
@@ -332,8 +328,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_reque
         MPIDI_OFI_win_datatype_unmap(&req->noncontig->origin_dt);
         MPIDI_OFI_win_datatype_unmap(&req->noncontig->result_dt);
         MPL_free(req->noncontig);
-        bucket = HANDLE_GET_BUCKET(req->handle);
-        MPIR_Handle_obj_free(&MPIR_Request_mem[bucket], (req));
+        MPIR_Handle_obj_free(&MPIR_Request_mem, (req));
     }
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -68,10 +68,8 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     case MPIDI_OFI_PEEK_NOT_FOUND:
         *flag = 0;
 
-        if (message) {
-            int bucket = HANDLE_GET_BUCKET(rreq->handle);
-            MPIR_Handle_obj_free(&MPIR_Request_mem[bucket], rreq);
-        }
+        if (message)
+            MPIR_Handle_obj_free(&MPIR_Request_mem, rreq);
 
         goto fn_exit;
         break;


### PR DESCRIPTION
remove the bucket scheme and add a cache in the per-thread object. all cached requests will leak after finalize.